### PR TITLE
Add invoice count retrieval functionality

### DIFF
--- a/dist/models/invoice.model.js
+++ b/dist/models/invoice.model.js
@@ -319,16 +319,19 @@ invoiceSchema.virtual('totalProfit').get(function () {
     return Math.round(totalProfit * 100) / 100;
 });
 // Static method to generate next invoice number
-invoiceSchema.statics.generateInvoiceNumber = function () {
+// Add static method to generate invoice ID
+invoiceSchema.statics.generateInvoiceId = function () {
     return __awaiter(this, void 0, void 0, function* () {
-        const lastInvoice = yield this.findOne({ isDeleted: false }, {}, { sort: { 'createdAt': -1 } });
-        if (!lastInvoice) {
-            return 'INV-1001';
+        const currentYear = new Date().getFullYear();
+        const prefix = `INV-${currentYear}-`;
+        // Find the last invoice with the current year prefix
+        const lastInvoice = yield this.findOne({ invoiceId: { $regex: `^${prefix}` } }, {}, { sort: { invoiceId: -1 } });
+        let nextNumber = 1;
+        if (lastInvoice && lastInvoice.invoiceId) {
+            const lastNumber = parseInt(lastInvoice.invoiceId.split('-').pop() || '0');
+            nextNumber = lastNumber + 1;
         }
-        const lastNumber = lastInvoice.invoiceNumber;
-        const numberPart = parseInt(lastNumber.split('-')[1]);
-        const nextNumber = numberPart + 1;
-        return `INV-${nextNumber}`;
+        return `${prefix}${nextNumber.toString().padStart(4, '0')}`;
     });
 };
 // Static method to get invoice statistics

--- a/dist/routes/invoice.routes.js
+++ b/dist/routes/invoice.routes.js
@@ -228,6 +228,60 @@ router.get('/', invoice_controller_1.getInvoices);
 router.get('/statistics', invoice_controller_1.getInvoiceStatistics);
 /**
  * @swagger
+ * /api/invoices/count:
+ *   get:
+ *     tags: [Invoices]
+ *     summary: Get invoice count for fiscal year
+ *     description: Retrieve the count of invoices for a specific fiscal year (April to March)
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: fiscalYear
+ *         schema:
+ *           type: integer
+ *         description: Fiscal year (e.g., 2024 for FY 2024-25). If not provided, current fiscal year is used.
+ *         example: 2024
+ *     responses:
+ *       200:
+ *         description: Invoice count retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 message:
+ *                   type: string
+ *                   example: Invoice count retrieved successfully
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     count:
+ *                       type: integer
+ *                       example: 150
+ *                     fiscalYear:
+ *                       type: integer
+ *                       example: 2024
+ *                     dateRange:
+ *                       type: object
+ *                       properties:
+ *                         start:
+ *                           type: string
+ *                           format: date-time
+ *                           example: 2024-04-01T00:00:00.000Z
+ *                         end:
+ *                           type: string
+ *                           format: date-time
+ *                           example: 2025-03-31T23:59:59.999Z
+ *       500:
+ *         description: Server error
+ */
+router.get('/count', invoice_controller_1.getInvoiceCount);
+/**
+ * @swagger
  * /api/invoices/{id}:
  *   get:
  *     tags: [Invoices]

--- a/src/routes/invoice.routes.ts
+++ b/src/routes/invoice.routes.ts
@@ -8,6 +8,7 @@ import {
   updateInvoicePayment,
   getInvoiceStatistics,
   updateInvoiceStatus,
+  getInvoiceCount,
 } from '../controllers/invoice.controller';
 import { authenticate, authorize } from '../middlewares/auth';
 
@@ -235,6 +236,61 @@ router.get('/', getInvoices);
  *         description: Statistics retrieved successfully
  */
 router.get('/statistics', getInvoiceStatistics);
+
+/**
+ * @swagger
+ * /api/invoices/count:
+ *   get:
+ *     tags: [Invoices]
+ *     summary: Get invoice count for fiscal year
+ *     description: Retrieve the count of invoices for a specific fiscal year (April to March)
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: fiscalYear
+ *         schema:
+ *           type: integer
+ *         description: Fiscal year (e.g., 2024 for FY 2024-25). If not provided, current fiscal year is used.
+ *         example: 2024
+ *     responses:
+ *       200:
+ *         description: Invoice count retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 message:
+ *                   type: string
+ *                   example: Invoice count retrieved successfully
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     count:
+ *                       type: integer
+ *                       example: 150
+ *                     fiscalYear:
+ *                       type: integer
+ *                       example: 2024
+ *                     dateRange:
+ *                       type: object
+ *                       properties:
+ *                         start:
+ *                           type: string
+ *                           format: date-time
+ *                           example: 2024-04-01T00:00:00.000Z
+ *                         end:
+ *                           type: string
+ *                           format: date-time
+ *                           example: 2025-03-31T23:59:59.999Z
+ *       500:
+ *         description: Server error
+ */
+router.get('/count', getInvoiceCount);
 
 /**
  * @swagger


### PR DESCRIPTION
- Introduced a new endpoint to fetch the count of invoices for a specified fiscal year, defaulting to the current fiscal year if not provided.
- Implemented logic to calculate the fiscal year based on the current date, with appropriate date range filtering for invoice counts.
- Updated Swagger documentation to include the new endpoint and its parameters for better API usability.